### PR TITLE
Fix code error in plugins.md, $banner to banner

### DIFF
--- a/docs/advanced/plugins.md
+++ b/docs/advanced/plugins.md
@@ -25,7 +25,7 @@ const site = lume();
 
 function addBanner(content: string): string {
   const banner = "/* © This code belongs to ACME inc. */";
-  return $banner + "\n" + content;
+  return banner + "\n" + content;
 }
 
 site.process([".css"], (pages) => {
@@ -50,7 +50,7 @@ interface Options {
 export default function (options: Options) {
   function addBanner(content: string): string {
     const banner = `/* ${options.message} */`;
-    return $banner + "\n" + content;
+    return banner + "\n" + content;
   }
 
   return (site: Site) => {
@@ -103,7 +103,7 @@ interface Options {
 export default function (options: Options) {
   function addBanner(content: string): string {
     const banner = `/* ${options.message} */`;
-    return $banner + "\n" + content;
+    return banner + "\n" + content;
   }
 
   return (site: Site) => {


### PR DESCRIPTION
return $banner did not work when I tested creating my own plugin using this plugin sample. VScode warned it should be just "banner", and sure enough, lume serve failed with an "unknown reference".